### PR TITLE
Drop Python 3.4 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
   include:
   - python: 2.7
     env: TEST_TARGET=default
-  - python: 3.4
-    env: TEST_TARGET=default
   - python: 3.5
     env: TEST_TARGET=default
   - python: 3.6


### PR DESCRIPTION
Some of the extra dependencies are no longer available for Python 3.4 and the 3.5/3.6 are enough for testing the code.